### PR TITLE
Update python_3.tmpl

### DIFF
--- a/editor/initial_code/python_3.tmpl
+++ b/editor/initial_code/python_3.tmpl
@@ -2,20 +2,20 @@
 {% block env %}{% endblock env %}
 
 {% block start %}
-def translate(text: str) -> str:
+def translation(text: str) -> str:
     # your code here
     return ""
 {% endblock start %}
 
 {% block example %}
 print('Example:')
-print(translate('hieeelalaooo'))
+print(translation('hieeelalaooo'))
 {% endblock %}
 
 # These "asserts" are used for self-checking
 {% block tests %}
 {% for t in tests %}
-assert {% block call %}translate({{t.input|p_args}})
+assert {% block call %}translation({{t.input|p_args}})
 {% endblock %} == {% block result %}{{t.answer|p}}{% endblock %}{% endfor %}
 {% endblock %}
 


### PR DESCRIPTION
The "translate" function needs to be renamed because its current name matches the built-in Python method. When I publish a solution with this function, the "translate" method appears in the "Most Recent Functions", while I did not use it.